### PR TITLE
Django 1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ matrix:
       env: DJANGO_VERSION=1.10
 install:
   - pip install -q Django==$DJANGO_VERSION
-  - pip install django-redis-cache
+  - pip install django-redis-cache==1.6.5
 script: python runtests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
       env: DJANGO_VERSION=1.8
     - python: '2.7'
       env: DJANGO_VERSION=1.9
+    - python: '2.7'
+      env: DJANGO_VERSION=1.10
 install:
   - pip install -q Django==$DJANGO_VERSION
   - pip install django-redis-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 language: python
 services:
   - redis-server
-python:
-  - '2.6'
-  - '2.7'
-env:
-  - DJANGO_VERSION=1.4
-  - DJANGO_VERSION=1.5
-  - DJANGO_VERSION=1.6
 matrix:
   include:
     - python: '2.7'
@@ -20,5 +13,5 @@ matrix:
       env: DJANGO_VERSION=1.10
 install:
   - pip install -q Django==$DJANGO_VERSION
-  - pip install django-redis-cache==1.6.5
+  - pip install django-redis-cache
 script: python runtests.py

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ django-simple-redis-admin
 
 Requirements
 ------------
-* Django >= 1.4 <= 1.9
+* Django >= 1.4 <= 1.10
 * A Django redis cache backend. I recommend [django-redis-cache](https://github.com/sebleier/django-redis-cache)
 
 Installation

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ django-simple-redis-admin
 
 Requirements
 ------------
-* Django >= 1.4 <= 1.10
+* Django >= 1.8 <= 1.10
 * A Django redis cache backend. I recommend [django-redis-cache](https://github.com/sebleier/django-redis-cache)
 
 Installation

--- a/redis_admin/admin.py
+++ b/redis_admin/admin.py
@@ -2,7 +2,6 @@ from django.contrib import admin
 from django.db import models
 from django.conf.urls import url
 from django.core.cache import cache
-from django.template import RequestContext
 from django.shortcuts import render
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, Http404

--- a/redis_admin/admin.py
+++ b/redis_admin/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.db import models
-from django.conf.urls import patterns
+from django.conf.urls import url
 from django.core.cache import cache
 from django.template import RequestContext
 from django.shortcuts import render_to_response
@@ -16,11 +16,11 @@ class RedisAdmin(admin.ModelAdmin):
     def get_urls(self):
         urls = super(RedisAdmin, self).get_urls()
 
-        my_urls = patterns('',
-            (r'^$', self.index),
-            (r'^(?P<key>.+)/delete/$', self.delete),
-            (r'^(?P<key>.+)/$', self.key),
-        )
+        my_urls = [
+            url(r'^$', self.index),
+            url(r'^(?P<key>.+)/delete/$', self.delete),
+            url(r'^(?P<key>.+)/$', self.key),
+        ]
         return my_urls + urls
 
     @method_decorator(user_passes_test(lambda u: u.is_superuser))
@@ -31,18 +31,18 @@ class RedisAdmin(admin.ModelAdmin):
             request.POST.get('post') == 'yes':
 
             if cache.master_client.delete(*request.POST.getlist('_selected_action')):
-                messages.add_message(request, messages.SUCCESS, 
+                messages.add_message(request, messages.SUCCESS,
                                     'Successfully deleted %d keys.' %
                                     len(request.POST.getlist('_selected_action')))
             else:
-                messages.add_message(request, messages.ERROR, 
+                messages.add_message(request, messages.ERROR,
                                     'Could not delete %d keys.' %
                                     len(request.POST.getlist('_selected_action')))
 
         elif request.method == 'POST' and request.POST.getlist('_selected_action') and \
             request.POST.get('action') == 'delete_selected':
- 
-            return render_to_response('redis_admin/delete_selected_confirmation.html', 
+
+            return render_to_response('redis_admin/delete_selected_confirmation.html',
                                      {'keys': request.POST.getlist('_selected_action')},
                                      context_instance=RequestContext(request))
 
@@ -81,7 +81,7 @@ class RedisAdmin(admin.ModelAdmin):
         elif key_type == 'set':
             context['value'] = str(cache.master_client.smembers(key))
 
-        return render_to_response('redis_admin/key.html', context, 
+        return render_to_response('redis_admin/key.html', context,
                                    context_instance=RequestContext(request))
 
     @method_decorator(user_passes_test(lambda u: u.is_superuser))
@@ -92,7 +92,7 @@ class RedisAdmin(admin.ModelAdmin):
             else:
                 messages.add_message(request, messages.ERROR, 'The key "%s" was not deleted successfully.' % key)
             return HttpResponseRedirect('%sredis_admin/manage/' % reverse('admin:index'))
-        return render_to_response('redis_admin/delete_confirmation.html', 
+        return render_to_response('redis_admin/delete_confirmation.html',
                                  {'key': key}, context_instance=RequestContext(request))
 
 class Meta:

--- a/redis_admin/admin.py
+++ b/redis_admin/admin.py
@@ -3,7 +3,7 @@ from django.db import models
 from django.conf.urls import url
 from django.core.cache import cache
 from django.template import RequestContext
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, Http404
 from django.contrib.auth.decorators import user_passes_test
@@ -42,9 +42,8 @@ class RedisAdmin(admin.ModelAdmin):
         elif request.method == 'POST' and request.POST.getlist('_selected_action') and \
             request.POST.get('action') == 'delete_selected':
 
-            return render_to_response('redis_admin/delete_selected_confirmation.html',
-                                     {'keys': request.POST.getlist('_selected_action')},
-                                     context_instance=RequestContext(request))
+            return render(request, 'redis_admin/delete_selected_confirmation.html',
+                         {'keys': request.POST.getlist('_selected_action')})
 
         if request.GET.get('q'):
             keys_result = cache.master_client.keys('*%s*' % request.GET.get('q'))
@@ -62,9 +61,8 @@ class RedisAdmin(admin.ModelAdmin):
         except EmptyPage:
             keys = paginator.page(paginator.num_pages)
 
-        return render_to_response('redis_admin/index.html', {'keys': keys, 
-                                  'count': paginator.count, 'page_range': paginator.page_range},
-                                   context_instance=RequestContext(request))
+        return render(request, 'redis_admin/index.html', {'keys': keys, 
+                     'count': paginator.count, 'page_range': paginator.page_range})
 
     @method_decorator(user_passes_test(lambda u: u.is_superuser))
     def key(self, request, key):
@@ -81,8 +79,7 @@ class RedisAdmin(admin.ModelAdmin):
         elif key_type == 'set':
             context['value'] = str(cache.master_client.smembers(key))
 
-        return render_to_response('redis_admin/key.html', context,
-                                   context_instance=RequestContext(request))
+        return render(request, 'redis_admin/key.html', context)
 
     @method_decorator(user_passes_test(lambda u: u.is_superuser))
     def delete(self, request, key):
@@ -92,8 +89,7 @@ class RedisAdmin(admin.ModelAdmin):
             else:
                 messages.add_message(request, messages.ERROR, 'The key "%s" was not deleted successfully.' % key)
             return HttpResponseRedirect('%sredis_admin/manage/' % reverse('admin:index'))
-        return render_to_response('redis_admin/delete_confirmation.html',
-                                 {'key': key}, context_instance=RequestContext(request))
+        return render(request, 'redis_admin/delete_confirmation.html', {'key': key})
 
 class Meta:
     app_label = 'redis_admin'

--- a/redis_admin/tests/test_admin.py
+++ b/redis_admin/tests/test_admin.py
@@ -1,26 +1,34 @@
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.test import TestCase
 
 
 class RedisAdminSanityTests(TestCase):
-    urls = 'redis_admin.tests.test_urls'
+    urls = 'redis_admin.tests.test_urls' # Deprecated in Django 1.10.
 
     def setUp(self):
         self.user = User.objects.create_superuser('test', 'test@test.com', 'password')
         self.client.login(username=self.user.username, password='password')
+        self.ROOT_URLCONF = getattr(settings, 'ROOT_URLCONF', None)
+        setattr(settings, 'ROOT_URLCONF', 'redis_admin.tests.test_urls')
 
     def test_admin_accessible(self):
         response = self.client.get('/admin/')
         self.assertEqual(200, response.status_code)
 
+    def tearDown(self):
+        setattr(settings, 'ROOT_URLCONF', self.ROOT_URLCONF)
+
 
 class RedisAdminViewsTests(TestCase):
-    urls = 'redis_admin.tests.test_urls'
+    urls = 'redis_admin.tests.test_urls' # Deprecated in Django 1.10.
 
     def setUp(self):
         self.user = User.objects.create_superuser('test', 'test@test.com', 'password')
         self.client.login(username=self.user.username, password='password')
+        self.ROOT_URLCONF = getattr(settings, 'ROOT_URLCONF', None)
+        setattr(settings, 'ROOT_URLCONF', 'redis_admin.tests.test_urls')
 
         cache.master_client.set('test-redis-admin', 'test')
 
@@ -42,3 +50,4 @@ class RedisAdminViewsTests(TestCase):
 
     def tearDown(self):
         cache.master_client.delete('test-redis-admin')
+        setattr(settings, 'ROOT_URLCONF', self.ROOT_URLCONF)

--- a/redis_admin/tests/test_admin.py
+++ b/redis_admin/tests/test_admin.py
@@ -1,34 +1,26 @@
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.test import TestCase
+from django.test import override_settings, TestCase
 
 
+@override_settings(ROOT_URLCONF='redis_admin.tests.test_urls')
 class RedisAdminSanityTests(TestCase):
-    urls = 'redis_admin.tests.test_urls' # Deprecated in Django 1.10.
 
     def setUp(self):
         self.user = User.objects.create_superuser('test', 'test@test.com', 'password')
         self.client.login(username=self.user.username, password='password')
-        self.ROOT_URLCONF = getattr(settings, 'ROOT_URLCONF', None)
-        setattr(settings, 'ROOT_URLCONF', 'redis_admin.tests.test_urls')
 
     def test_admin_accessible(self):
         response = self.client.get('/admin/')
         self.assertEqual(200, response.status_code)
 
-    def tearDown(self):
-        setattr(settings, 'ROOT_URLCONF', self.ROOT_URLCONF)
 
-
+@override_settings(ROOT_URLCONF='redis_admin.tests.test_urls')
 class RedisAdminViewsTests(TestCase):
-    urls = 'redis_admin.tests.test_urls' # Deprecated in Django 1.10.
 
     def setUp(self):
         self.user = User.objects.create_superuser('test', 'test@test.com', 'password')
         self.client.login(username=self.user.username, password='password')
-        self.ROOT_URLCONF = getattr(settings, 'ROOT_URLCONF', None)
-        setattr(settings, 'ROOT_URLCONF', 'redis_admin.tests.test_urls')
 
         cache.master_client.set('test-redis-admin', 'test')
 
@@ -50,4 +42,3 @@ class RedisAdminViewsTests(TestCase):
 
     def tearDown(self):
         cache.master_client.delete('test-redis-admin')
-        setattr(settings, 'ROOT_URLCONF', self.ROOT_URLCONF)

--- a/redis_admin/tests/test_urls.py
+++ b/redis_admin/tests/test_urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
-)
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Django==1.4
-django-redis-cache
+django-redis-cache==1.6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django==1.4
-django-redis-cache==1.6.5
+Django>=1.8
+django-redis-cache

--- a/runtests.py
+++ b/runtests.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python
+import os
 import sys
 from django.conf import settings
 from django.core.management import execute_from_command_line
 
+
 if not settings.configured:
+    TEMPLATE_DEBUG = True
+    TEMPLATE_DIRS = [
+        os.path.join(os.path.dirname(__file__), 'redis_admin', 'templates'),
+    ]
     settings.configure(
         DATABASES={
             'default': {
@@ -37,7 +43,28 @@ if not settings.configured:
                     'MIN_COMPRESSION_LEN': 102400,
                 },
             }
-        }
+        },
+        TEMPLATES = [
+            {
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'DIRS': TEMPLATE_DIRS,
+                'APP_DIRS': True,
+                'OPTIONS': {
+                    'debug': TEMPLATE_DEBUG,
+                    'context_processors': [
+                        'django.contrib.auth.context_processors.auth',
+                        'django.template.context_processors.debug',
+                        'django.template.context_processors.i18n',
+                        'django.template.context_processors.media',
+                        'django.template.context_processors.static',
+                        'django.template.context_processors.tz',
+                        'django.contrib.messages.context_processors.messages',
+                    ],
+                },
+            },
+        ],
+        TEMPLATE_DIRS=TEMPLATE_DIRS,
+        TEMPLATE_DEBUG=TEMPLATE_DEBUG
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-simple-redis-admin',
-    version='1.3.0',
+    version='1.4.0',
     description='A django admin application to manage redis cache keys.',
     long_description=open('README.md').read(),
     author='Nicholas Serra',


### PR DESCRIPTION
- Added Django 1.10 entry to travis.
- Modified README.md to reflect new Django version range.
- Removed deprecated `patterns` usage.
- Modified all `render_to_response` references to `render` to simplify `context_instance` parameter deprecation and removed unused `RequestContext` import.
- Dropped support for Django < 1.8.