### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,19 @@ matrix:
       env: DJANGO_VERSION=1.9
     - python: '2.7'
       env: DJANGO_VERSION=1.10
+    # Adding job ppc64le
+    - python: '2.7'
+      arch: ppc64le
+      env: DJANGO_VERSION=1.7
+    - python: '2.7'
+      arch: ppc64le
+      env: DJANGO_VERSION=1.8
+    - python: '2.7'
+      arch: ppc64le
+      env: DJANGO_VERSION=1.9
+    - python: '2.7'
+      arch: ppc64le
+      env: DJANGO_VERSION=1.10
 install:
   - pip install -q Django==$DJANGO_VERSION
   - pip install django-redis-cache


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on Travis-CI in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The Travis-CI build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/django-simple-redis-admin/builds/189058738

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj